### PR TITLE
Fix merged text recognition

### DIFF
--- a/lanyocr/__init__.py
+++ b/lanyocr/__init__.py
@@ -36,6 +36,7 @@ class LanyOcr:
         if merge_boxes_inference and recognizer_name in [
             "mmocr_satrn",
             "mmocr_satrn_sm",
+            "paddleocr_en_ppocr_v3",
         ]:
             merge_boxes_inference = False
             print(

--- a/lanyocr/__init__.py
+++ b/lanyocr/__init__.py
@@ -39,9 +39,14 @@ class LanyOcr:
             "paddleocr_en_ppocr_v3",
         ]:
             merge_boxes_inference = False
-            print(
-                f"Disabled merge_boxes_inference because {recognizer_name} could not recognize space character."
-            )
+            if recognizer_name == "paddleocr_en_ppocr_v3":
+                print(
+                    f"Disabled merge_boxes_inference because {recognizer_name} has dynamic input width."
+                )
+            else:
+                print(
+                    f"Disabled merge_boxes_inference because {recognizer_name} could not recognize space character."
+                )
 
         self.detector = LanyOcrDetectorFactory.create(detector_name, use_gpu=use_gpu)
         self.recognizer = LanyOcrRecognizerFactory.create(


### PR DESCRIPTION
- Disable merge_boxes_inference for "paddleocr_en_ppocr_v3" because we don't know how long the width should be to get good results.