### PR TITLE
Fix deprecated np.int0 usage.

### DIFF
--- a/lanyocr/__init__.py
+++ b/lanyocr/__init__.py
@@ -180,7 +180,7 @@ class LanyOcr:
                     line_angle = line_angle
 
             points = cv2.boxPoints(line_rrect)
-            box = np.int0(np.array(points))
+            box = np.int64(np.array(points))
             center_x = np.sum(box[:, 0]) // 4
             center_y = np.sum(box[:, 1]) // 4
 
@@ -256,7 +256,7 @@ class LanyOcr:
             if visualize_sub_boxes:
                 for sub_rrect in result.line.sub_rrects:
                     points = sub_rrect.points
-                    box = np.int0(np.array(points))
+                    box = np.int64(np.array(points))
                     vis_img = cv2.drawContours(
                         vis_img, [box], 0, COLORS[(idx + 1) % len(COLORS)], 1
                     )


### PR DESCRIPTION
This pull request addresses the usage of the deprecated np.int0 function in the codebase. The np.int0 type has been marked for deprecation in recent versions of NumPy, which may lead to compatibility issues in future updates. This change replaces np.int0 with np.int64, ensuring that the code adheres to current best practices and maintains compatibility with newer versions of NumPy.

This fix improves code reliability and prevents potential errors that could arise from using deprecated functions. Please review the changes and consider merging them into the main branch.






