### PR TITLE
Fix deprecated np.int0 usage

### DIFF
--- a/lanyocr/lanyocr_utils.py
+++ b/lanyocr/lanyocr_utils.py
@@ -188,7 +188,7 @@ def check_merged_size(text_line: LanyOcrTextLine, rrect: LanyOcrRRect):
 
 def crop_rect(img, rrect):
     points = cv2.boxPoints(rrect)
-    box = np.int0(np.array(points))
+    box = np.int64(np.array(points))
 
     min_x = np.min(box[:, 0])
     max_x = np.max(box[:, 0])


### PR DESCRIPTION
This pull request addresses the usage of the deprecated np.int0 function in the codebase. The np.int0 type has been marked for deprecation in recent versions of NumPy, which may lead to compatibility issues in future updates. This change replaces np.int0 with np.int64, ensuring that the code adheres to current best practices and maintains compatibility with newer versions of NumPy.

This fix improves code reliability and prevents potential errors that could arise from using deprecated functions. Please review the changes and consider merging them into the main branch.